### PR TITLE
Fix keyboard mods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ travis-ci = { repository = "michaelfairley/rust-imgui-sdl2" }
 
 [dependencies]
 imgui = "0.0.21"
-sdl2 = "^0"
+sdl2 = ">=0.32.1"
 
 [dev-dependencies]
 gl = "0.10.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,10 +102,10 @@ impl ImguiSdl2 {
     use sdl2::keyboard;
 
     fn set_mod(imgui: &mut ImGui, keymod: keyboard::Mod) {
-      let ctrl = keymod.intersects(keyboard::RCTRLMOD | keyboard::LCTRLMOD);
-      let alt = keymod.intersects(keyboard::RALTMOD | keyboard::LALTMOD);
-      let shift = keymod.intersects(keyboard::RSHIFTMOD | keyboard::LSHIFTMOD);
-      let super_ = keymod.intersects(keyboard::RGUIMOD | keyboard::LGUIMOD);
+      let ctrl = keymod.intersects(keyboard::Mod::RCTRLMOD | keyboard::Mod::LCTRLMOD);
+      let alt = keymod.intersects(keyboard::Mod::RALTMOD | keyboard::Mod::LALTMOD);
+      let shift = keymod.intersects(keyboard::Mod::RSHIFTMOD | keyboard::Mod::LSHIFTMOD);
+      let super_ = keymod.intersects(keyboard::Mod::RGUIMOD | keyboard::Mod::LGUIMOD);
 
       imgui.set_key_ctrl(ctrl);
       imgui.set_key_alt(alt);


### PR DESCRIPTION
rust-sdl2 0.32.1 contains a API change in this commit:
https://github.com/Rust-SDL2/rust-sdl2/commit/8f27656a6ad5eb7a4bc1f6ce591129ca161c60a9#diff-1c9cdf66ee7b0ad39b5f2a2d85a442e4

I've also updated the constraint in Cargo.toml, though I'm not sure about the syntax.