### PR TITLE
Bump SDL2 version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "imgui-sdl2"
 description = "SDL2 Input handling for imgui-rs"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Michael Fairley <michael@michaelfairley.com>"]
 homepage = "https://github.com/michaelfairley/rust-imgui-sdl2"
 repository = "https://github.com/michaelfairley/rust-imgui-sdl2"
@@ -14,7 +14,7 @@ travis-ci = { repository = "michaelfairley/rust-imgui-sdl2" }
 
 [dependencies]
 imgui = "0.2"
-sdl2 = "0.32.1"
+sdl2 = "0.33"
 
 [dev-dependencies]
 gl = "0.10.0"


### PR DESCRIPTION
Not sure if upping the version should be part of this pull request, but changing the version of SDL2 doesn't break anything in the example (nor would I expect it to).