### PR TITLE
update to imgui 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT/Apache-2.0"
 travis-ci = { repository = "michaelfairley/rust-imgui-sdl2" }
 
 [dependencies]
-imgui = "0.4"
+imgui = "0.5"
 sdl2 = "0.34"
 
 [dev-dependencies]


### PR DESCRIPTION
This requires that the other pull request on the rust-imgui-opengl-renderer is accepted, and the version of it is updated in this repo as well.