### PR TITLE
Update the dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "imgui-sdl2"
 description = "SDL2 Input handling for imgui-rs"
-version = "0.15.3"
+version = "0.16.0"
 authors = ["Michael Fairley <michael@michaelfairley.com>"]
 homepage = "https://github.com/michaelfairley/rust-imgui-sdl2"
 repository = "https://github.com/michaelfairley/rust-imgui-sdl2"
@@ -10,9 +10,9 @@ categories = ["gui"]
 license = "MIT/Apache-2.0"
 
 [dependencies]
-imgui = ">=0.8.0, <0.12.0"
-sdl2 = ">=0.34, <0.37"
+imgui = "0.12"
+sdl2 = "0.38"
 
 [dev-dependencies]
-gl = "0.10.0"
-imgui-opengl-renderer = "0.12.1"
+gl = "0.14"
+imgui-opengl-renderer = "0.13"


### PR DESCRIPTION
Updates the dependencies to make it usable again. Requires https://github.com/michaelfairley/rust-imgui-opengl-renderer/pull/27 to work.